### PR TITLE
Fix shuffled country selection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -89,7 +89,7 @@ const App: React.FC = () => {
       allCountries,
       selectedRegion
     );
-    const shuffledCountries = filteredCountries
+    const shuffledCountries = [...filteredCountries]
       .sort(() => 0.5 - Math.random())
       .slice(0, selectedTotal);
 


### PR DESCRIPTION
## Summary
- prevent in-place sorting of `filteredCountries` in `handleStart`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68889fa4d7b88333ae65e14e3a986025