### PR TITLE
Add quit button to interrupt quiz

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,6 +142,7 @@ const App: React.FC = () => {
           totalQuestions={totalQuestions}
           onAnswer={handleAnswer}
           setUserAnswer={setUserAnswer}
+          onQuit={restartQuiz}
         />
       )}
       {screen === "feedback" && (
@@ -152,6 +153,7 @@ const App: React.FC = () => {
           currentIndex={questionIndex}
           totalQuestions={totalQuestions}
           onNext={nextQuestion}
+          onQuit={restartQuiz}
         />
       )}
       {screen === "result" && (

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,10 @@
   @apply px-6 py-2 font-semibold text-white transition-colors bg-blue-600 rounded hover:bg-blue-700;
 }
 
+.btn-quit {
+  @apply w-full max-w-xs px-4 py-2 font-semibold text-white transition bg-red-600 rounded hover:bg-red-700;
+}
+
 .heading-main {
   @apply mb-4 text-3xl font-bold;
 }

--- a/src/screens/FeedbackScreen.tsx
+++ b/src/screens/FeedbackScreen.tsx
@@ -8,6 +8,7 @@ interface FeedbackScreenProps {
   onNext: () => void;
   currentIndex: number;
   totalQuestions: number;
+  onQuit: () => void;
 }
 
 export const FeedbackScreen: React.FC<FeedbackScreenProps> = ({
@@ -17,6 +18,7 @@ export const FeedbackScreen: React.FC<FeedbackScreenProps> = ({
   onNext,
   currentIndex,
   totalQuestions,
+  onQuit,
 }) => {
   const message = isCorrect ? "Correct! 🎉" : "Wrong! ❌";
   const buttonText =
@@ -50,6 +52,9 @@ export const FeedbackScreen: React.FC<FeedbackScreenProps> = ({
       <div className="mt-6">
         <button className="btn-main" onClick={onNext}>
           {buttonText}
+        </button>
+        <button className="btn-quit mt-4" onClick={onQuit}>
+          Quit Quiz
         </button>
       </div>
     </div>

--- a/src/screens/QuizScreen.tsx
+++ b/src/screens/QuizScreen.tsx
@@ -9,6 +9,7 @@ interface QuizScreenProps {
   totalQuestions: number;
   onAnswer: (userAnswer: string) => void;
   setUserAnswer: (userAnswer: string) => void;
+  onQuit: () => void;
 }
 
 const getOptions = (countries: Country[], correctCountry: Country) => {
@@ -27,6 +28,7 @@ export const QuizScreen: React.FC<QuizScreenProps> = ({
   totalQuestions,
   onAnswer,
   setUserAnswer,
+  onQuit,
 }) => {
   const [input, setInput] = useState("");
 
@@ -82,6 +84,11 @@ export const QuizScreen: React.FC<QuizScreenProps> = ({
           </button>
         </div>
       )}
+      <div className="mt-6">
+        <button className="btn-quit" onClick={onQuit}>
+          Quit Quiz
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a Quit button during the quiz and feedback screens
- style new button with red color

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888a0e41ab883339a5e77f3e69fc832