### PR TITLE
Redesign UI with Apple aesthetics

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,11 @@
-@import 'tailwindcss';
+@import "tailwindcss";
+
+body {
+  @apply min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 text-gray-900 font-sans;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", Roboto,
+    sans-serif;
+}
 
 /* --- Start Screen --- */
 .start-container {
@@ -6,11 +13,11 @@
 }
 
 .start-title {
-  @apply mb-8 text-3xl font-bold;
+  @apply mb-8 text-4xl font-extrabold tracking-tight;
 }
 
 .select-group {
-  @apply w-full max-w-xs mb-4;
+  @apply w-full max-w-xs mb-4 mx-auto;
 }
 
 .select-group:last-of-type {
@@ -26,7 +33,7 @@
 }
 
 .start-button {
-  @apply px-6 py-2 font-semibold text-white transition bg-blue-600 rounded hover:bg-blue-700;
+  @apply px-8 py-3 font-semibold text-white transition-colors bg-blue-600 rounded-full hover:bg-blue-700;
 }
 
 /* --- Quiz Screen --- */
@@ -35,21 +42,21 @@
 }
 
 .input-main {
-  @apply w-full p-2 text-lg border rounded;
+  @apply w-full p-2 text-lg border rounded-lg;
 }
 
 .btn-option {
-  @apply w-full max-w-[320px] mx-auto px-4 py-2 text-lg text-gray-800 bg-white border 
-         border-blue-500 rounded shadow hover:bg-blue-100 transition text-center;
+  @apply w-full max-w-[320px] mx-auto px-6 py-2 text-lg text-gray-800 bg-white border border-blue-500 rounded-full shadow hover:bg-blue-100 transition text-center;
 }
 
 /* --- Feedback Screen --- */
+
 .heading-correct {
-  @apply mb-4 text-3xl font-bold text-green-600;
+  @apply mb-4 text-3xl font-semibold text-green-600;
 }
 
 .heading-wrong {
-  @apply mb-4 text-3xl font-bold text-red-600;
+  @apply mb-4 text-3xl font-semibold text-red-600;
 }
 
 /* --- Result Screen --- */
@@ -59,30 +66,33 @@
 
 /* --- Common --- */
 .screen-wrapper {
-  @apply relative flex flex-col items-center justify-center min-h-screen px-4 bg-gray-100;
+  @apply relative flex flex-col items-center justify-center min-h-screen px-4 w-full;
+}
+
+.screen-card {
+  @apply relative w-full max-w-md p-6 bg-white/80 rounded-xl shadow-lg backdrop-blur border border-gray-200 mx-auto text-center;
 }
 
 .flag-image {
-  @apply object-contain h-40 w-auto mb-4 bg-blue-50 border border-gray-200 shadow mx-auto;
+  @apply object-contain h-40 w-auto mb-4 bg-white border border-gray-200 shadow rounded-lg mx-auto;
 }
 
 .btn-main {
-  @apply w-full max-w-xs px-4 py-2 font-semibold text-white transition-colors bg-blue-600 rounded hover:bg-blue-700;
+  @apply w-full max-w-xs px-8 py-3 font-semibold text-white transition-colors bg-blue-600 rounded-full hover:bg-blue-700;
 }
 
 .btn-quit {
-  @apply w-full max-w-xs px-4 py-2 font-semibold text-white transition bg-red-600 rounded hover:bg-red-700;
+  @apply w-full max-w-xs px-8 py-3 font-semibold text-white transition bg-red-600 rounded-full hover:bg-red-700;
 }
 
 .btn-quit-top {
-  @apply absolute top-4 right-4 px-3 py-1 font-semibold text-white transition bg-red-600 rounded hover:bg-red-700;
+  @apply absolute top-4 right-4 px-3 py-1 font-semibold text-white transition bg-red-600 rounded-full hover:bg-red-700;
 }
 
 .heading-main {
-  @apply mb-4 text-3xl font-bold;
+  @apply mb-4 text-4xl font-extrabold tracking-tight;
 }
 
 .paragraph-main {
-  @apply mb-2 text-lg;
+  @apply mb-2 text-lg text-gray-700;
 }
-

--- a/src/screens/FeedbackScreen.tsx
+++ b/src/screens/FeedbackScreen.tsx
@@ -26,36 +26,38 @@ export const FeedbackScreen: React.FC<FeedbackScreenProps> = ({
 
   return (
     <div className="screen-wrapper">
-      <button className="btn-quit-top" onClick={onQuit}>
-        Quit Quiz
-      </button>
-      <h2 className={isCorrect ? "heading-correct" : "heading-wrong"}>
-        {message}
-      </h2>
-
-      <p className="paragraph-main">
-        Question {currentIndex + 1} of {totalQuestions}
-      </p>
-
-      {!isCorrect && (
-        <div className="mb-4 text-red-600">
-          <p className="paragraph-main">Your answer: {userAnswer}</p>
-        </div>
-      )}
-
-      <p className="paragraph-main">Correct answer:</p>
-      <p className="mb-4 text-xl font-bold">{correctCountry.name}</p>
-
-      <img
-        src={`https://flagcdn.com/${correctCountry.code.toLowerCase()}.svg`}
-        alt={`Flag of ${correctCountry?.name}`}
-        className="flag-image"
-      />
-
-      <div className="mt-6">
-        <button className="btn-main" onClick={onNext}>
-          {buttonText}
+      <div className="screen-card">
+        <button className="btn-quit-top" onClick={onQuit}>
+          Quit Quiz
         </button>
+        <h2 className={isCorrect ? "heading-correct" : "heading-wrong"}>
+          {message}
+        </h2>
+
+        <p className="paragraph-main">
+          Question {currentIndex + 1} of {totalQuestions}
+        </p>
+
+        {!isCorrect && (
+          <div className="mb-4 text-red-600">
+            <p className="paragraph-main">Your answer: {userAnswer}</p>
+          </div>
+        )}
+
+        <p className="paragraph-main">Correct answer:</p>
+        <p className="mb-4 text-xl font-bold">{correctCountry.name}</p>
+
+        <img
+          src={`https://flagcdn.com/${correctCountry.code.toLowerCase()}.svg`}
+          alt={`Flag of ${correctCountry?.name}`}
+          className="flag-image"
+        />
+
+        <div className="mt-6">
+          <button className="btn-main" onClick={onNext}>
+            {buttonText}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/screens/QuizScreen.tsx
+++ b/src/screens/QuizScreen.tsx
@@ -39,54 +39,56 @@ export const QuizScreen: React.FC<QuizScreenProps> = ({
 
   return (
     <div className="screen-wrapper">
-      <button className="btn-quit-top" onClick={onQuit}>
-        Quit Quiz
-      </button>
-      <p className="mb-4 text-lg font-semibold">
-        Question {questionIndex + 1} of {totalQuestions}
-      </p>
+      <div className="screen-card">
+        <p className="mb-4 text-lg font-semibold">
+          Question {questionIndex + 1} of {totalQuestions}
+        </p>
 
-      <div
-        style={{
-          minHeight: 160,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        <img
-          src={`https://flagcdn.com/${correctCountry.code.toLowerCase()}.svg`}
-          alt="Flag"
-          className="flag-image"
-        />
-      </div>
-
-      {mode === "easy" ? (
-        <div className="option-container">
-          {getOptions(countries, correctCountry).map((country) => (
-            <button
-              key={country.name}
-              className="btn-option"
-              onClick={() => handleSubmit(country.name)}
-            >
-              {country.name}
-            </button>
-          ))}
-        </div>
-      ) : (
-        <div className="items-center option-container">
-          <input
-            className="input-main"
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Enter country name"
+        <div
+          style={{
+            minHeight: 160,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <img
+            src={`https://flagcdn.com/${correctCountry.code.toLowerCase()}.svg`}
+            alt="Flag"
+            className="flag-image"
           />
-          <button className="btn-main" onClick={() => handleSubmit(input)}>
-            Submit
-          </button>
         </div>
-      )}
+
+        {mode === "easy" ? (
+          <div className="option-container">
+            {getOptions(countries, correctCountry).map((country) => (
+              <button
+                key={country.name}
+                className="btn-option"
+                onClick={() => handleSubmit(country.name)}
+              >
+                {country.name}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="items-center option-container">
+            <input
+              className="input-main"
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Enter country name"
+            />
+            <button className="btn-main" onClick={() => handleSubmit(input)}>
+              Submit
+            </button>
+          </div>
+        )}
+        <button className="btn-quit-top" onClick={onQuit}>
+          Quit Quiz
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -13,15 +13,17 @@ export const ResultScreen: React.FC<ResultScreenProps> = ({
 }) => {
   return (
     <div className="screen-wrapper">
-      <h2 className="heading-main">Quiz Finished!</h2>
-      <p className="paragraph-main">You scored:</p>
-      <p className="text-score">
-        {score} / {total}
-      </p>
+      <div className="screen-card">
+        <h2 className="heading-main">Quiz Finished!</h2>
+        <p className="paragraph-main">You scored:</p>
+        <p className="text-score">
+          {score} / {total}
+        </p>
 
-      <button className="btn-main" onClick={onRestart}>
-        Play Again
-      </button>
+        <button className="btn-main" onClick={onRestart}>
+          Play Again
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -45,59 +45,61 @@ export const StartScreen: React.FC<{
 
   return (
     <div className="screen-wrapper">
-      <h1 className="start-title">Flag Quiz</h1>
+      <div className="screen-card">
+        <h1 className="start-title">Flag Quiz</h1>
 
-      <div className="select-group">
-        <label className="select-label">Select Mode:</label>
-        <select
-          className="select-input"
-          value={selectedMode}
-          onChange={(e) => setSelectedMode(e.target.value as Mode)}
-        >
-          <option value="easy">Easy (Multiple Choice)</option>
-          <option value="hard">Hard (Input)</option>
-        </select>
-      </div>
-
-      <div className="select-group">
-        <label className="select-label">Select Region:</label>
-        <select
-          className="select-input"
-          value={selectedRegion}
-          onChange={(e) => setSelectedRegion(e.target.value as Region)}
-        >
-          {regions.map((region) => (
-            <option key={region} value={region}>
-              {region}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div className="select-group">
-        <label className="select-label">Number of Questions:</label>
-        <select
-          className="select-input"
-          value={selectedCount}
-          onChange={(e) => setSelectedCount(Number(e.target.value))}
-        >
-          {countsWithAll.map((count) => (
-            <option key={count} value={count}>
-              {count === maxCount ? `All (${maxCount})` : count}
-            </option>
-          ))}
-        </select>
-        <div className="text-sm text-gray-500 mt-1">
-          {maxCount} countries in this region
+        <div className="select-group">
+          <label className="select-label">Select Mode:</label>
+          <select
+            className="select-input"
+            value={selectedMode}
+            onChange={(e) => setSelectedMode(e.target.value as Mode)}
+          >
+            <option value="easy">Easy (Multiple Choice)</option>
+            <option value="hard">Hard (Input)</option>
+          </select>
         </div>
-      </div>
 
-      <button
-        className="start-button"
-        onClick={() => onStart(selectedMode, selectedRegion, selectedCount)}
-      >
-        Start
-      </button>
+        <div className="select-group">
+          <label className="select-label">Select Region:</label>
+          <select
+            className="select-input"
+            value={selectedRegion}
+            onChange={(e) => setSelectedRegion(e.target.value as Region)}
+          >
+            {regions.map((region) => (
+              <option key={region} value={region}>
+                {region}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="select-group">
+          <label className="select-label">Number of Questions:</label>
+          <select
+            className="select-input"
+            value={selectedCount}
+            onChange={(e) => setSelectedCount(Number(e.target.value))}
+          >
+            {countsWithAll.map((count) => (
+              <option key={count} value={count}>
+                {count === maxCount ? `All (${maxCount})` : count}
+              </option>
+            ))}
+          </select>
+          <div className="text-sm text-gray-500 mt-1">
+            {maxCount} countries in this region
+          </div>
+        </div>
+
+        <button
+          className="start-button"
+          onClick={() => onStart(selectedMode, selectedRegion, selectedCount)}
+        >
+          Start
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- center select groups within the start screen card
- make `.screen-card` relative so the quit button anchors to it instead of the wrapper
- format the updated files with Prettier after merge fix

## Testing
- `npm test`
- `npm run lint` (with warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6888a863845c83338d8792f5fe5d3c7f