### PR TITLE
Handle tab close as quiz pause

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,6 +158,39 @@ const App: React.FC = () => {
     setScreen("start");
   };
 
+  // Treat closing or reloading the tab as pausing the quiz
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      const next = screen === "feedback" ? "feedback-next" : screen;
+      const data = {
+        screen: "start",
+        mode,
+        questionIndex,
+        score,
+        countries,
+        userAnswer,
+        isCorrect,
+        totalQuestions,
+        isPaused: true,
+        resumeScreen: next,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [
+    screen,
+    mode,
+    questionIndex,
+    score,
+    countries,
+    userAnswer,
+    isCorrect,
+    totalQuestions,
+  ]);
+
   return (
     <div className="min-h-screen text-gray-800 bg-gray-50">
       {screen === "start" && (


### PR DESCRIPTION
## Summary
- pause the quiz in `beforeunload` so reopening starts on the start screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888b2ebcdd08333ab87eb6653876458