### PR TITLE
Improve responsive Apple-style design

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,7 @@ body {
 
 /* --- Start Screen --- */
 .start-container {
-  @apply flex flex-col items-center justify-center min-h-screen px-4 mx-auto max-w-md bg-white/70 backdrop-blur rounded-xl shadow-lg p-6 sm:p-8;
+  @apply card;
 }
 
 .start-title {
@@ -67,7 +67,11 @@ body {
 
 /* --- Common --- */
 .screen-wrapper {
-  @apply relative flex flex-col items-center justify-center min-h-screen px-4 mx-auto max-w-screen-md text-center bg-gray-100 pt-20 sm:pt-24;
+  @apply flex items-center justify-center min-h-screen px-4 bg-gray-100;
+}
+
+.card {
+  @apply relative w-full max-w-md bg-white/80 backdrop-blur rounded-xl shadow-lg p-6 sm:p-8 text-center pt-20 sm:pt-24;
 }
 
 .flag-image {

--- a/src/index.css
+++ b/src/index.css
@@ -6,9 +6,6 @@ body {
 }
 
 /* --- Start Screen --- */
-.start-container {
-  @apply card;
-}
 
 .start-title {
   @apply mb-8 text-4xl font-semibold text-gray-800;

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,7 @@ body {
 }
 
 .select-group {
-  @apply w-full max-w-xs mb-4;
+  @apply w-full max-w-xs mb-4 mx-auto;
 }
 
 .select-group:last-of-type {

--- a/src/index.css
+++ b/src/index.css
@@ -1,12 +1,17 @@
 @import 'tailwindcss';
 
+body {
+  @apply font-sans bg-gray-50 text-gray-900;
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", sans-serif;
+}
+
 /* --- Start Screen --- */
 .start-container {
-  @apply flex flex-col items-center justify-center min-h-screen px-4;
+  @apply flex flex-col items-center justify-center min-h-screen px-4 mx-auto max-w-md bg-white/70 backdrop-blur rounded-xl shadow-lg p-6 sm:p-8;
 }
 
 .start-title {
-  @apply mb-8 text-3xl font-bold;
+  @apply mb-8 text-4xl font-semibold text-gray-800;
 }
 
 .select-group {
@@ -22,15 +27,15 @@
 }
 
 .select-input {
-  @apply w-full p-2 border rounded;
+  @apply w-full p-2 border border-gray-300 rounded-lg bg-gray-50;
 }
 
 .start-button {
-  @apply px-6 py-2 font-semibold text-white transition bg-blue-600 rounded hover:bg-blue-700;
+  @apply px-6 py-2 font-semibold text-white transition-colors bg-blue-600 rounded-full hover:bg-blue-700;
 }
 
 .resume-button {
-  @apply px-6 py-2 font-semibold text-white transition bg-green-600 rounded hover:bg-green-700;
+  @apply px-6 py-2 font-semibold text-white transition-colors bg-green-600 rounded-full hover:bg-green-700;
 }
 
 /* --- Quiz Screen --- */
@@ -39,12 +44,11 @@
 }
 
 .input-main {
-  @apply w-full p-2 text-lg border rounded;
+  @apply w-full p-2 text-lg border border-gray-300 rounded-lg bg-gray-50;
 }
 
 .btn-option {
-  @apply w-full max-w-[320px] mx-auto px-4 py-2 text-lg text-gray-800 bg-white border 
-         border-blue-500 rounded shadow hover:bg-blue-100 transition text-center;
+  @apply w-full max-w-[320px] mx-auto px-4 py-2 text-lg text-gray-800 bg-white border border-blue-500 rounded-full shadow hover:bg-blue-100 transition text-center;
 }
 
 /* --- Feedback Screen --- */
@@ -63,11 +67,11 @@
 
 /* --- Common --- */
 .screen-wrapper {
-  @apply relative flex flex-col items-center justify-center min-h-screen px-4 bg-gray-100;
+  @apply relative flex flex-col items-center justify-center min-h-screen px-4 mx-auto max-w-screen-md text-center bg-gray-100 pt-20 sm:pt-24;
 }
 
 .flag-image {
-  @apply object-contain h-40 w-auto mb-4 bg-blue-50 border border-gray-200 shadow mx-auto;
+  @apply object-contain h-40 w-auto mb-4 bg-blue-50 border border-gray-200 shadow rounded-lg mx-auto;
 }
 
 .btn-main {
@@ -79,7 +83,7 @@
 }
 
 .btn-quit-top {
-  @apply absolute top-4 right-4 px-3 py-1 font-semibold text-white transition bg-red-600 rounded hover:bg-red-700;
+  @apply absolute top-4 right-4 sm:top-6 sm:right-6 px-3 py-1 font-semibold text-white transition bg-red-600 rounded hover:bg-red-700;
 }
 
 .heading-main {

--- a/src/screens/FeedbackScreen.tsx
+++ b/src/screens/FeedbackScreen.tsx
@@ -26,12 +26,13 @@ export const FeedbackScreen: React.FC<FeedbackScreenProps> = ({
 
   return (
     <div className="screen-wrapper">
-      <button className="btn-quit-top" onClick={onPause}>
-        Pause Quiz
-      </button>
-      <h2 className={isCorrect ? "heading-correct" : "heading-wrong"}>
-        {message}
-      </h2>
+      <div className="card">
+        <button className="btn-quit-top" onClick={onPause}>
+          Pause Quiz
+        </button>
+        <h2 className={isCorrect ? "heading-correct" : "heading-wrong"}>
+          {message}
+        </h2>
 
       <p className="paragraph-main">
         Question {currentIndex + 1} of {totalQuestions}
@@ -52,10 +53,11 @@ export const FeedbackScreen: React.FC<FeedbackScreenProps> = ({
         className="flag-image"
       />
 
-      <div className="mt-6">
-        <button className="btn-main" onClick={onNext}>
-          {buttonText}
-        </button>
+        <div className="mt-6">
+          <button className="btn-main" onClick={onNext}>
+            {buttonText}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/screens/QuizScreen.tsx
+++ b/src/screens/QuizScreen.tsx
@@ -39,12 +39,13 @@ export const QuizScreen: React.FC<QuizScreenProps> = ({
 
   return (
     <div className="screen-wrapper">
-      <button className="btn-quit-top" onClick={onPause}>
-        Pause Quiz
-      </button>
-      <p className="mb-4 text-lg font-semibold">
-        Question {questionIndex + 1} of {totalQuestions}
-      </p>
+      <div className="card">
+        <button className="btn-quit-top" onClick={onPause}>
+          Pause Quiz
+        </button>
+        <p className="mb-4 text-lg font-semibold">
+          Question {questionIndex + 1} of {totalQuestions}
+        </p>
 
       <div
         style={{
@@ -61,32 +62,33 @@ export const QuizScreen: React.FC<QuizScreenProps> = ({
         />
       </div>
 
-      {mode === "easy" ? (
-        <div className="option-container">
-          {getOptions(countries, correctCountry).map((country) => (
-            <button
-              key={country.name}
-              className="btn-option"
-              onClick={() => handleSubmit(country.name)}
-            >
-              {country.name}
+        {mode === "easy" ? (
+          <div className="option-container">
+            {getOptions(countries, correctCountry).map((country) => (
+              <button
+                key={country.name}
+                className="btn-option"
+                onClick={() => handleSubmit(country.name)}
+              >
+                {country.name}
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div className="items-center option-container">
+            <input
+              className="input-main"
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Enter country name"
+            />
+            <button className="btn-main" onClick={() => handleSubmit(input)}>
+              Submit
             </button>
-          ))}
-        </div>
-      ) : (
-        <div className="items-center option-container">
-          <input
-            className="input-main"
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Enter country name"
-          />
-          <button className="btn-main" onClick={() => handleSubmit(input)}>
-            Submit
-          </button>
-        </div>
-      )}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -13,15 +13,17 @@ export const ResultScreen: React.FC<ResultScreenProps> = ({
 }) => {
   return (
     <div className="screen-wrapper">
-      <h2 className="heading-main">Quiz Finished!</h2>
-      <p className="paragraph-main">You scored:</p>
-      <p className="text-score">
-        {score} / {total}
-      </p>
+      <div className="card">
+        <h2 className="heading-main">Quiz Finished!</h2>
+        <p className="paragraph-main">You scored:</p>
+        <p className="text-score">
+          {score} / {total}
+        </p>
 
-      <button className="btn-main" onClick={onRestart}>
-        Play Again
-      </button>
+        <button className="btn-main" onClick={onRestart}>
+          Play Again
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -47,7 +47,8 @@ export const StartScreen: React.FC<{
 
   return (
     <div className="screen-wrapper">
-      <h1 className="start-title">Flag Quiz</h1>
+      <div className="card">
+        <h1 className="start-title">Flag Quiz</h1>
 
       <div className="select-group">
         <label className="select-label">Select Mode:</label>
@@ -99,12 +100,13 @@ export const StartScreen: React.FC<{
           Resume
         </button>
       )}
-      <button
-        className="start-button"
-        onClick={() => onStart(selectedMode, selectedRegion, selectedCount)}
-      >
-        Start
-      </button>
+        <button
+          className="start-button"
+          onClick={() => onStart(selectedMode, selectedRegion, selectedCount)}
+        >
+          Start
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- modernize layout with responsive Apple-inspired styles
- keep quit button spaced away from question text on mobile

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888b555067c8333ac781b66554e41db