### PR TITLE
Refactor app logic into utility modules

### DIFF
--- a/src/screens/FeedbackScreen.tsx
+++ b/src/screens/FeedbackScreen.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import type { Country } from "../types";
 
+// Shows whether the previous answer was correct and reveals the flag
+
 interface FeedbackScreenProps {
   isCorrect: boolean;
   correctCountry: Country;
@@ -20,6 +22,7 @@ export const FeedbackScreen: React.FC<FeedbackScreenProps> = ({
   totalQuestions,
   onPause,
 }) => {
+  // Text and next action depend on whether the answer was correct
   const message = isCorrect ? "Correct! 🎉" : "Wrong! ❌";
   const buttonText =
     currentIndex + 1 === totalQuestions ? "See Results 🏁" : "Next Question ➡️";

--- a/src/screens/QuizScreen.tsx
+++ b/src/screens/QuizScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import type { Country, Mode } from "../types";
+import { getOptions } from "../utils/quiz";
 
 interface QuizScreenProps {
   mode: Mode;
@@ -12,13 +13,7 @@ interface QuizScreenProps {
   onPause: () => void;
 }
 
-const getOptions = (countries: Country[], correctCountry: Country) => {
-  const shuffled = [...countries]
-    .filter((country) => country.name !== correctCountry.name)
-    .sort(() => 0.5 - Math.random())
-    .slice(0, 3);
-  return [...shuffled, correctCountry].sort(() => 0.5 - Math.random());
-};
+// Shows the current question and accepts an answer from the user
 
 export const QuizScreen: React.FC<QuizScreenProps> = ({
   mode,
@@ -32,6 +27,7 @@ export const QuizScreen: React.FC<QuizScreenProps> = ({
 }) => {
   const [input, setInput] = useState("");
 
+  // Forward the selected or typed answer to the parent component
   const handleSubmit = (answer: string) => {
     setUserAnswer(answer);
     onAnswer(answer);

--- a/src/screens/ResultScreen.tsx
+++ b/src/screens/ResultScreen.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+// Final screen showing the user's score
+
 interface ResultScreenProps {
   score: number;
   total: number;

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -1,16 +1,8 @@
 import React, { useState } from "react";
 import type { Mode, Region, Country } from "../types";
+import { REGIONS, QUESTION_COUNTS } from "../utils/constants";
 
-const regions: Region[] = [
-  "World",
-  "Africa",
-  "Americas",
-  "Asia",
-  "Europe",
-  "Oceania",
-];
-
-const questionCounts = [5, 10, 20, 30, 40, 50, 100];
+// Initial configuration screen where the user selects mode and region
 
 export const StartScreen: React.FC<{
   onStart: (mode: Mode, region: Region, totalQuestions: number) => void;
@@ -22,28 +14,37 @@ export const StartScreen: React.FC<{
   const [selectedRegion, setSelectedRegion] = useState<Region>("World");
   const [selectedCount, setSelectedCount] = useState<number>(10);
 
-  // 選択中regionの国数を計算
-  const filteredCountries =
-    selectedRegion === "World"
-      ? allCountries
-      : allCountries.filter((c) => c.region === selectedRegion);
+  // Number of countries in the currently selected region
+  const filteredCountries = React.useMemo(
+    () =>
+      selectedRegion === "World"
+        ? allCountries
+        : allCountries.filter((c) => c.region === selectedRegion),
+    [selectedRegion, allCountries]
+  );
   const maxCount = filteredCountries.length;
 
-  // region内の国数以下の選択肢だけ表示
-  const availableCounts = questionCounts.filter((count) => count <= maxCount);
+  // Offer only question counts that fit within this region
+  const availableCounts = React.useMemo(
+    () => QUESTION_COUNTS.filter((count) => count <= maxCount),
+    [maxCount]
+  );
 
-  // 「すべて」選択肢を追加
-  const countsWithAll = [
-    ...availableCounts,
-    ...(availableCounts.includes(maxCount) ? [] : [maxCount]),
-  ];
+  // Add an "All" option representing every country
+  const countsWithAll = React.useMemo(
+    () => [
+      ...availableCounts,
+      ...(availableCounts.includes(maxCount) ? [] : [maxCount]),
+    ],
+    [availableCounts, maxCount]
+  );
 
-  // 選択肢が変更された際に、現在の値が選択肢に存在しなければ修正
+  // Ensure the selected count is valid when the region changes
   React.useEffect(() => {
     if (!countsWithAll.includes(selectedCount)) {
       setSelectedCount(countsWithAll[countsWithAll.length - 1]);
     }
-  }, [selectedRegion]);
+  }, [selectedRegion, countsWithAll, selectedCount]);
 
   return (
     <div className="screen-wrapper">
@@ -69,7 +70,7 @@ export const StartScreen: React.FC<{
           value={selectedRegion}
           onChange={(e) => setSelectedRegion(e.target.value as Region)}
         >
-          {regions.map((region) => (
+          {REGIONS.map((region) => (
             <option key={region} value={region}>
               {region}
             </option>

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,3 +7,8 @@ export type Country = {
 export type Mode = "easy" | "hard";
 
 export type Region = "World" | "Africa" | "Americas" | "Asia" | "Europe" | "Oceania";
+
+// Screens used by the main application
+export type Screen = "start" | "quiz" | "feedback" | "result";
+// Screen value stored when pausing the quiz
+export type ResumeScreen = Screen | "feedback-next";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,14 @@
+import type { Region } from "../types";
+
+/** Available regions the user can choose from */
+export const REGIONS: Region[] = [
+  "World",
+  "Africa",
+  "Americas",
+  "Asia",
+  "Europe",
+  "Oceania",
+];
+
+/** Default question count options */
+export const QUESTION_COUNTS = [5, 10, 20, 30, 40, 50, 100];

--- a/src/utils/country.ts
+++ b/src/utils/country.ts
@@ -1,0 +1,28 @@
+import type { Country } from "../types";
+
+/** Shape of the raw country data loaded from JSON */
+interface RawCountry {
+  name?: { common?: string };
+  cca2?: string;
+  region?: string;
+}
+
+/**
+ * Normalize the raw country list to the simplified Country type used in the app.
+ */
+export const normalizeCountries = (data: RawCountry[]): Country[] =>
+  data.map((country) => ({
+    name: country.name?.common || "Unknown",
+    code: country.cca2 || "",
+    region: country.region || "Other",
+  }));
+
+/**
+ * Filter countries by region. When "World" is selected the whole array is
+ * returned without modifications.
+ */
+export const filterCountriesByRegion = (
+  countries: Country[],
+  region: string
+): Country[] =>
+  region === "World" ? countries : countries.filter((c) => c.region === region);

--- a/src/utils/quiz.ts
+++ b/src/utils/quiz.ts
@@ -1,0 +1,17 @@
+import type { Country } from "../types";
+
+/**
+ * Build a list of multiple choice options for a question.
+ * The returned array contains the correct country and three random other countries.
+ */
+export const getOptions = (
+  countries: Country[],
+  correctCountry: Country
+): Country[] => {
+  const shuffled = [...countries]
+    .filter((c) => c.name !== correctCountry.name)
+    .sort(() => 0.5 - Math.random())
+    .slice(0, 3);
+
+  return [...shuffled, correctCountry].sort(() => 0.5 - Math.random());
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,34 @@
+import type { Country, Mode, Screen, ResumeScreen } from "../types";
+
+/** Key used for persisting quiz state in localStorage */
+export const STORAGE_KEY = "flag-quiz-state";
+
+/** Structure of the persisted quiz state */
+export interface PersistedState {
+  screen: Screen;
+  mode: Mode;
+  questionIndex: number;
+  score: number;
+  countries: Country[];
+  userAnswer: string;
+  isCorrect: boolean;
+  totalQuestions: number;
+  isPaused: boolean;
+  resumeScreen: ResumeScreen;
+}
+
+/** Load the quiz state from localStorage */
+export const loadState = (): Partial<PersistedState> | null => {
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (!saved) return null;
+  try {
+    return JSON.parse(saved) as Partial<PersistedState>;
+  } catch {
+    return null;
+  }
+};
+
+/** Save the quiz state to localStorage */
+export const saveState = (state: PersistedState) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+};


### PR DESCRIPTION
## Summary
- move normalization and filtering helpers to `src/utils/country.ts`
- add quiz helper `getOptions` and central constants
- extract localStorage logic to `src/utils/storage.ts`
- export screen types in `src/types.ts`
- update components to use new helpers and add English comments
- improve StartScreen state logic with `useMemo`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888c09d57708333b6db3c0010cf28e7