### PR TITLE
Fix alt text and add strict region typing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { QuizScreen } from "./screens/QuizScreen";
 import { FeedbackScreen } from "./screens/FeedbackScreen";
 import { ResultScreen } from "./screens/ResultScreen";
 import countriesData from "./data/country.json";
-import type { Country, Mode, Screen, ResumeScreen } from "./types";
+import type { Country, Mode, Screen, ResumeScreen, Region } from "./types";
 import { normalizeCountries, filterCountriesByRegion } from "./utils/country";
 import { loadState, saveState, STORAGE_KEY } from "./utils/storage";
 
@@ -70,7 +70,7 @@ const App: React.FC = () => {
 
   const handleStart = (
     selectedMode: Mode,
-    selectedRegion: string,
+    selectedRegion: Region,
     selectedTotal: number
   ) => {
     // Prepare the quiz using the chosen options

--- a/src/screens/QuizScreen.tsx
+++ b/src/screens/QuizScreen.tsx
@@ -46,7 +46,7 @@ export const QuizScreen: React.FC<QuizScreenProps> = ({
         <div className="flex-1 flex items-center justify-center">
           <img
             src={`https://flagcdn.com/${correctCountry.code.toLowerCase()}.svg`}
-            alt="Flag"
+            alt={`Flag of ${correctCountry.name}`}
             className="flag-image"
           />
         </div>

--- a/src/utils/country.ts
+++ b/src/utils/country.ts
@@ -1,4 +1,4 @@
-import type { Country } from "../types";
+import type { Country, Region } from "../types";
 
 /** Shape of the raw country data loaded from JSON */
 interface RawCountry {
@@ -23,6 +23,6 @@ export const normalizeCountries = (data: RawCountry[]): Country[] =>
  */
 export const filterCountriesByRegion = (
   countries: Country[],
-  region: string
+  region: Region
 ): Country[] =>
   region === "World" ? countries : countries.filter((c) => c.region === region);


### PR DESCRIPTION
## Summary
- improve accessibility by providing descriptive alt text for flag images
- tighten region type usage in the app and utility functions

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888c68f2ef0833382dfdc17be7da53d