### PR TITLE
Fix layout spacing issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,7 +175,7 @@ const App: React.FC = () => {
   ]);
 
   return (
-    <div className="min-h-screen text-gray-800 bg-gray-50">
+    <div className="min-h-screen text-gray-800 bg-gray-100">
       {screen === "start" && (
         <StartScreen
           onStart={handleStart}

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
 body {
-  @apply font-sans bg-gray-50 text-gray-800 text-base sm:text-lg;
+  @apply font-sans bg-gray-100 text-gray-800 text-base sm:text-lg;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", sans-serif;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -79,7 +79,8 @@ body {
 
 .card {
   @apply relative w-full max-w-md bg-white/80 backdrop-blur rounded-xl shadow-lg p-6 sm:p-8 text-center pt-16 sm:pt-20;
-  height: calc(100svh - 2rem);
+  /* allow the card to shrink when there's little content but never exceed the viewport */
+  max-height: calc(100svh - 2rem);
   display: flex;
   flex-direction: column;
   overflow-y: auto;

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
 
 body {
   @apply font-sans bg-gray-50 text-gray-800 text-base sm:text-lg;
+  margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", sans-serif;
 }
 

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -49,7 +49,7 @@ export const StartScreen: React.FC<{
   return (
     <div className="screen-wrapper">
       <div className="card flex flex-col">
-        <div className="flex-grow">
+        <div className="grow-0 sm:grow">
           <h1 className="start-title">Flag Quiz 🌎</h1>
 
           <div className="select-group">


### PR DESCRIPTION
## Summary
- remove default body margin so no white border appears
- adjust StartScreen layout so buttons aren't stuck at the bottom on small screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6888db4764b8833382dd48fe721262d1