### PR TITLE
Fix mobile viewport scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <link rel="manifest" href="/manifest.json" />
     <title>Flag Quiz</title>
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,13 @@
+{
+  "name": "Flag Quiz",
+  "short_name": "Flags",
+  "start_url": ".",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "vite.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,7 +175,7 @@ const App: React.FC = () => {
   ]);
 
   return (
-    <div className="min-h-screen text-gray-800 bg-gray-100">
+    <div className="min-h-[100dvh] text-gray-800 bg-gray-100 overscroll-none">
       {screen === "start" && (
         <StartScreen
           onStart={handleStart}

--- a/src/index.css
+++ b/src/index.css
@@ -74,7 +74,9 @@ body {
 /* --- Common --- */
 
 .screen-wrapper {
-  @apply flex items-center justify-center min-h-screen px-4 bg-gray-100;
+  /* use dynamic viewport units to avoid extra scrolling on mobile */
+  @apply flex items-center justify-center min-h-[100dvh] px-4 bg-gray-100;
+  overscroll-behavior: none;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- prevent extra vertical scroll by using 100dvh
- disable overscroll to give more app‑like feel
- add PWA manifest and meta tag for fullscreen

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888e4fa7e988333afd139bd44c54679